### PR TITLE
Fixed version conflict with dart 2.1.0/flutter 0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,5 +8,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+environment:
+  sdk: ">=2.0.0-dev.58.0 <3.0.0"
+
 dev_dependencies:
   test: ^0.12.0


### PR DESCRIPTION
Check https://github.com/flutter/flutter/issues/20700 for more info.

Issue is resolved by just setting a minimum environment version for the
plugin.

Closes:
https://github.com/gbrvalerio/carousel/issues/10