### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.0.0-dev.58.0 <3.0.0"
+  sdk: ">=1.23.0<=2.1.0"
 
 dev_dependencies:
   test: ^0.12.0


### PR DESCRIPTION
app] flutter packages get
Running "flutter packages get" in app...                        
The current Dart SDK version is 2.1.2-dev.0.0.flutter-0a7dcf17eb.

Because app depends on carousel >=0.1.0 which requires SDK version <2.0.0, version solving failed